### PR TITLE
fix remain settings if setting window canceled

### DIFF
--- a/imageClipPaste/ViewModel/ApplicationSettingViewModel.cs
+++ b/imageClipPaste/ViewModel/ApplicationSettingViewModel.cs
@@ -30,13 +30,13 @@ namespace imageClipPaste.ViewModel
         }
 
         /// <summary>
-        /// Excel貼り付け設定
+        /// 画像を貼り付けたあとで、アクティブなセルを画像の下に移動するか
         /// </summary>
-        private Settings.PasteExcelSetting excelSetting;
-        public Settings.PasteExcelSetting ExcelSetting
+        private bool moveActiveCellInImageBelow;
+        public bool MoveActiveCellInImageBelow
         {
-            get { return excelSetting; }
-            set { Set(ref excelSetting, value); }
+            get { return moveActiveCellInImageBelow; }
+            set { Set(ref moveActiveCellInImageBelow, value); }
         }
         #endregion
 
@@ -55,9 +55,25 @@ namespace imageClipPaste.ViewModel
                     Properties.Settings.Default.Setting.ClipboardMonitorIntervalMilliseconds = 
                         IntervalMilliseconds;
                     Properties.Settings.Default.Setting.IsClipAutoConvertibleImage = IsClipAutoConvertibleImage;
-                    Properties.Settings.Default.Setting.ExcelSetting = ExcelSetting;
+                    Properties.Settings.Default.Setting.ExcelSetting.MoveActiveCellInImageBelow = MoveActiveCellInImageBelow;
 
                     Properties.Settings.Default.Save();
+                });
+            }
+        }
+
+        /// <summary>
+        /// OKボタンコマンド
+        /// </summary>
+        private RelayCommand onWindowClosing;
+        public RelayCommand OnWindowClosing
+        {
+            get
+            {
+                return onWindowClosing = onWindowClosing ?? new RelayCommand(() =>
+                {
+                    // ウィンドウを閉じるときにViewModalをリセットする
+                    LoadApplicationSettings();
                 });
             }
         }
@@ -68,12 +84,19 @@ namespace imageClipPaste.ViewModel
         /// </summary>
         public ApplicationSettingViewModel()
         {
-            // アプリケーションの設定を読み込む
-            IntervalMilliseconds = 
+            LoadApplicationSettings();
+        }
+
+        /// <summary>
+        /// アプリケーションの設定を読み込む
+        /// </summary>
+        private void LoadApplicationSettings()
+        {
+            IntervalMilliseconds =
                 Properties.Settings.Default.Setting.ClipboardMonitorIntervalMilliseconds;
             IsClipAutoConvertibleImage = Properties.Settings.Default.Setting.IsClipAutoConvertibleImage;
-            ExcelSetting =
-                Properties.Settings.Default.Setting.ExcelSetting;
+            MoveActiveCellInImageBelow =
+                Properties.Settings.Default.Setting.ExcelSetting.MoveActiveCellInImageBelow;
         }
 
         /// <summary>

--- a/imageClipPaste/Views/ApplicationSettingWindow.xaml
+++ b/imageClipPaste/Views/ApplicationSettingWindow.xaml
@@ -12,7 +12,13 @@
     ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner"
     Title="オプション" Height="300" Width="320"
     DataContext="{Binding ApplicationSetting, Source={StaticResource Locator}}" SizeToContent="Height">
-    
+
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="Closing">
+            <i:InvokeCommandAction Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window}, Path=DataContext.OnWindowClosing}" CommandParameter="{Binding}"/>
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <Window.Resources>
         <!--
         <ObjectDataProvider x:Key="PasteTypeProvider" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
@@ -61,7 +67,7 @@
 
         <Label Content="Excelへの貼り付け" Style="{StaticResource HeaderLabelStyle}" />
         <StackPanel Margin="15, 5, 0, 0">
-            <CheckBox Content="貼り付け後、アクティブセルを画像の下に移動する" IsChecked="{Binding ExcelSetting.MoveActiveCellInImageBelow}" />
+            <CheckBox Content="貼り付け後、アクティブセルを画像の下に移動する" IsChecked="{Binding MoveActiveCellInImageBelow}" />
         </StackPanel>
         
         <Separator Opacity="0" Height="20"/>


### PR DESCRIPTION
設定ウィンドウを「キャンセル」 またはクローズウィンドウで閉じたとき、
未確定の設定が表示上残ってしまうのを修正。